### PR TITLE
fix: update base image to python:3.14.5-slim-trixie in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-ARG BASE_IMAGE=python:3.10.18-slim-trixie
+ARG BASE_IMAGE=python:3.14.5-slim-trixie
 
 
 # Here is the production image


### PR DESCRIPTION
This pull request makes a minor update to the `Dockerfile` by upgrading the base Python image from version 3.10.18 to 3.14.5. This ensures the application uses a more recent Python runtime and benefits from the latest features and security patches.