### PR TITLE
Upgrade actions/checkout and actions/setup-python to version 7

### DIFF
--- a/.github/workflows/1.bump-version.yml
+++ b/.github/workflows/1.bump-version.yml
@@ -17,7 +17,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: Bump version
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/2.build-publish.yml
+++ b/.github/workflows/2.build-publish.yml
@@ -21,7 +21,7 @@ jobs:
       actions: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: Get latest version
         run: |
           git pull origin main

--- a/.github/workflows/2.build-publish.yml
+++ b/.github/workflows/2.build-publish.yml
@@ -1,6 +1,7 @@
 name: 2. Build and Publish
 
 on:
+  workflow_dispatch:
   workflow_run:
     workflows: ["1. Bump Version"]
     types:

--- a/.github/workflows/3.create-release.yml
+++ b/.github/workflows/3.create-release.yml
@@ -21,7 +21,7 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: Create release
         run: ./scripts/release.sh
       - name: Check Workflow

--- a/.github/workflows/4.update-changelog.yml
+++ b/.github/workflows/4.update-changelog.yml
@@ -15,7 +15,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: Update changelog
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,0 +1,43 @@
+name: Pre-Commit
+
+on:
+  pull_request:
+    branches:
+      - main
+      - dev
+    types:
+      - opened
+      - synchronize
+      - reopened
+
+jobs:
+  pre-commit:
+    name: Run pre-commit checks
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+      - name: Set up Python
+        uses: actions/setup-python@v7
+        with:
+          python-version: "3.10"
+      - name: Cache pip
+        uses: actions/cache@v6
+        with:
+          path: ~/.cache/pip
+          key: pip-${{ runner.os }}-${{ hashFiles('requirements.txt') }}
+      - name: Install pre-commit and dependencies
+        run: |
+          python -m pip install -U pip
+          python -m pip install -r ./requirements.txt
+      - name: Cache pre-commit
+        uses: actions/cache@v6
+        with:
+          path: ~/.cache/pre-commit
+          key: pre-commit-${{ runner.os }}-${{ hashFiles('.pre-commit-config.yaml') }}
+      - name: Run pre-commit on all files
+        run: |
+          pre-commit run --all-files --show-diff-on-failure --color=always

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -17,7 +17,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
       - name: Set up Python

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -21,7 +21,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: "3.10"
       - name: Install dependencies

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -92,6 +92,16 @@ repos:
         name: "🐚 shellcheck - Lint shell scripts"
         files: \.sh$
 
+  # --- Markdown ---
+  - repo: https://github.com/igorshubovych/markdownlint-cli
+    rev: v0.49.1
+    hooks:
+      - id: markdownlint
+        name: "📝 markdownlint - Lint markdown files"
+        args: ["--fix"]
+        exclude: |
+          (?x)^(docs/release-notes.md|CHANGELOG.md)$
+
   # --- Cleanup ---
   # - repo: local
   #   hooks:

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -8,7 +8,6 @@
 		"alefragnani.project-manager",
 		"pkief.material-icon-theme",
 		"aaron-bond.better-comments",
-		"gruntfuggly.todo-tree",
 		"piotrpalarz.vscode-gitignore-generator",
 		"timonwong.shellcheck",
 		"davidanson.vscode-markdownlint",

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-ARG BASE_IMAGE=python:3.14.5-slim-trixie
+ARG BASE_IMAGE=python:3.14.6-slim-trixie
 
 
 # Here is the production image


### PR DESCRIPTION
This pull request introduces several updates to the CI/CD workflows, dependency versions, and development tooling. The main focus is on upgrading GitHub Actions to their latest versions, adding a pre-commit workflow for improved code quality, and updating dependencies for Python and markdown linting. Below are the most important changes, grouped by theme:

**CI/CD Workflow Improvements:**

* Upgraded all usages of `actions/checkout` and `actions/setup-python` in workflow files to their latest major versions (`v7`), ensuring better security and support. [[1]](diffhunk://#diff-b2e2e8b9910fdf6b98fa2f5713471dae660b6aba5d48bf6b59ecb99cb679f0d1L20-R20) [[2]](diffhunk://#diff-c06acd67a77a30e433d009852aa65d7eadc0d0d86dca6ad99d9a5b1a764b0ce7L24-R25) [[3]](diffhunk://#diff-43f0f5a64fe03df7574739bee10c527b7c8eb810f87b37a78e4cb012eec0425dL24-R24) [[4]](diffhunk://#diff-20c2a854a43ea7d9039581ed3fd179dd8f549d65e3e88e27c380a317d40ffdacL18-R18) [[5]](diffhunk://#diff-dd751c654ce34c435239f846704cbba01f2aef90c73ad219db2d47789b369544L20-R24)
* Added a `workflow_dispatch` trigger to `.github/workflows/2.build-publish.yml`, allowing manual runs of the build and publish workflow.

**Pre-commit and Linting Enhancements:**

* Introduced a new `.github/workflows/pre-commit.yml` workflow to automatically run pre-commit checks on pull requests targeting `main` and `dev` branches. This includes Python setup, dependency caching, and running all pre-commit hooks.
* Added a `markdownlint` hook to `.pre-commit-config.yaml` to automatically lint and fix markdown files, excluding `docs/release-notes.md` and `CHANGELOG.md`.

**Dependency Updates:**

* Updated the base Python image in `Dockerfile` from `python:3.14.5-slim-trixie` to `python:3.14.6-slim-trixie` for the latest bug fixes and security patches.

**Development Tooling:**

* Removed the `gruntfuggly.todo-tree` extension from `.vscode/extensions.json`, possibly to streamline recommended extensions.